### PR TITLE
add alternative tag logic

### DIFF
--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -2,6 +2,7 @@ package domain
 
 import "errors"
 
+// Errors for export.
 var (
 	ErrTagShort        = errors.New("tag can't be less then 3 bytes")
 	ErrTagInvalidStart = errors.New("tag must start from open bracket symbol")

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -1,0 +1,9 @@
+package domain
+
+import "errors"
+
+var (
+	ErrTagShort        = errors.New("tag can't be less then 3 bytes")
+	ErrTagInvalidStart = errors.New("tag must start from open bracket symbol")
+	ErrTagInvalidEnd   = errors.New("tag must end with close bracket symbol")
+)

--- a/internal/domain/tag.go
+++ b/internal/domain/tag.go
@@ -1,8 +1,6 @@
 package domain
 
 import (
-	"fmt"
-
 	"github.com/tty2/xq/internal/domain/symbol"
 )
 
@@ -52,7 +50,7 @@ func (t *Tag) SetName() error {
 		}
 	}
 
-	t.Name = fmt.Sprint(t.Bytes[startName:endName])
+	t.Name = string(t.Bytes[startName:endName])
 
 	return nil
 }
@@ -76,7 +74,11 @@ func (t *Tag) SetNameAndAttributes() error {
 		}
 	}
 
-	t.Name = fmt.Sprint(t.Bytes[startName:endName])
+	t.Name = string(t.Bytes[startName:endName])
+
+	if startName == 2 {
+		return nil // it's forbidden to set attributes to close tag
+	}
 
 	var insideTag bool
 	t.Attributes = map[string]string{}
@@ -85,7 +87,7 @@ func (t *Tag) SetNameAndAttributes() error {
 		if insideTag {
 			if symbol.IsQuote(t.Bytes[i]) {
 				if len(attr.Name) != 0 {
-					t.Attributes[fmt.Sprint(attr.Name)] = fmt.Sprint(attr.Value)
+					t.Attributes[string(attr.Name)] = string(attr.Value)
 
 					attr = attribute{}
 					insideTag = false
@@ -97,10 +99,10 @@ func (t *Tag) SetNameAndAttributes() error {
 
 			continue
 		}
-		if t.Bytes[i] != '=' {
+		if t.Bytes[i] == '=' {
 			continue
 		}
-		if symbol.IsQuote(t.Bytes[i]) && t.Bytes[i-1] != '=' {
+		if symbol.IsQuote(t.Bytes[i]) && t.Bytes[i-1] == '=' {
 			insideTag = true
 
 			continue
@@ -111,13 +113,4 @@ func (t *Tag) SetNameAndAttributes() error {
 	}
 
 	return nil
-}
-
-func (t *Tag) GetAttributeValue(name string) (string, error) {
-	v, ok := t.Attributes[name]
-	if !ok {
-		return "", fmt.Errorf("there is no attribute with name %s", name)
-	}
-
-	return v, nil
 }

--- a/internal/domain/tag.go
+++ b/internal/domain/tag.go
@@ -1,0 +1,123 @@
+package domain
+
+import (
+	"fmt"
+
+	"github.com/tty2/xq/internal/domain/symbol"
+)
+
+type Tag struct {
+	Bytes      []byte
+	Name       string
+	Attributes map[string]string
+}
+
+type attribute struct {
+	Name  []byte
+	Value []byte
+}
+
+func (t *Tag) Validate() error {
+	if len(t.Bytes) < 3 {
+		return ErrTagShort
+	}
+
+	if t.Bytes[0] != symbol.OpenBracket {
+		return ErrTagInvalidStart
+	}
+
+	if t.Bytes[len(t.Bytes)-1] != symbol.CloseBracket {
+		return ErrTagInvalidEnd
+	}
+
+	return nil
+}
+
+func (t *Tag) SetName() error {
+	err := t.Validate()
+	if err != nil {
+		return err
+	}
+
+	startName := 1         // name starts after open bracket
+	if t.Bytes[1] == '/' { // closed tag
+		startName = 2
+	}
+
+	endName := startName
+
+	for ; endName < len(t.Bytes)-1; endName++ {
+		if t.Bytes[endName] == ' ' {
+			break
+		}
+	}
+
+	t.Name = fmt.Sprint(t.Bytes[startName:endName])
+
+	return nil
+}
+
+func (t *Tag) SetNameAndAttributes() error {
+	err := t.Validate()
+	if err != nil {
+		return err
+	}
+
+	startName := 1         // name starts after open bracket
+	if t.Bytes[1] == '/' { // closed tag
+		startName = 2
+	}
+
+	endName := startName
+
+	for ; endName < len(t.Bytes)-1; endName++ {
+		if t.Bytes[endName] == ' ' {
+			break
+		}
+	}
+
+	t.Name = fmt.Sprint(t.Bytes[startName:endName])
+
+	var insideTag bool
+	t.Attributes = map[string]string{}
+	attr := attribute{}
+	for i := endName; i < len(t.Bytes)-1; i++ {
+		if insideTag {
+			if symbol.IsQuote(t.Bytes[i]) {
+				if len(attr.Name) != 0 {
+					t.Attributes[fmt.Sprint(attr.Name)] = fmt.Sprint(attr.Value)
+
+					attr = attribute{}
+					insideTag = false
+				}
+
+				continue
+			}
+			attr.Value = append(attr.Value, t.Bytes[i])
+
+			continue
+		}
+		if t.Bytes[i] != '=' {
+			continue
+		}
+		if symbol.IsQuote(t.Bytes[i]) && t.Bytes[i-1] != '=' {
+			insideTag = true
+
+			continue
+		}
+		if t.Bytes[i] != ' ' {
+			attr.Name = append(attr.Name, t.Bytes[i])
+		}
+	}
+
+	return nil
+}
+
+func (t *Tag) GetAttributeValue(name string) (string, error) {
+	v, ok := t.Attributes[name]
+	if !ok {
+		return "", fmt.Errorf("there is no attribute with name %s", name)
+	}
+
+	return v, nil
+}

--- a/internal/domain/tag.go
+++ b/internal/domain/tag.go
@@ -4,6 +4,11 @@ import (
 	"github.com/tty2/xq/internal/domain/symbol"
 )
 
+// Tag represents a tag object.
+// It make sense to work with is with `Bytes` field populated only otherwise all the methods
+// will not work.
+// `Bytes` field MUST start from open bracket `<` and finish with close bracket `>` and
+// MUST be 3 symbols or bigger otherwise tag is invalid.
 type Tag struct {
 	Bytes      []byte
 	Name       string
@@ -15,6 +20,8 @@ type attribute struct {
 	Value []byte
 }
 
+// Validate checks if tag `Bytes` has 3 or more symbols, starts with open bracket
+// and the last symbol is close bracket.
 func (t *Tag) Validate() error {
 	if len(t.Bytes) < 3 {
 		return ErrTagShort
@@ -31,6 +38,7 @@ func (t *Tag) Validate() error {
 	return nil
 }
 
+// SetName takes name from tag and set to `Name` field.
 func (t *Tag) SetName() error {
 	err := t.Validate()
 	if err != nil {
@@ -55,6 +63,8 @@ func (t *Tag) SetName() error {
 	return nil
 }
 
+// SetNameAndAttributes takes name from tag and set it to `Name` field +
+// takes all attributes and their values and put them to `Attributes`.
 func (t *Tag) SetNameAndAttributes() error {
 	err := t.Validate()
 	if err != nil {

--- a/internal/domain/tag_test.go
+++ b/internal/domain/tag_test.go
@@ -58,3 +58,149 @@ func TestValidateTag(t *testing.T) {
 		rq.NoError(err)
 	})
 }
+
+func TestTagSetName(t *testing.T) {
+	t.Parallel()
+	rq := require.New(t)
+
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+
+		tg := Tag{
+			Bytes: []byte("<tagname>"),
+		}
+		rq.Equal("", tg.Name)
+
+		err := tg.SetName()
+		rq.NoError(err)
+		rq.Equal("tagname", tg.Name)
+	})
+
+	t.Run("close tag", func(t *testing.T) {
+		t.Parallel()
+
+		tg := Tag{
+			Bytes: []byte("</tagname>"),
+		}
+		rq.Equal("", tg.Name)
+
+		err := tg.SetName()
+		rq.NoError(err)
+		rq.Equal("tagname", tg.Name)
+	})
+
+	t.Run("empty tag", func(t *testing.T) {
+		t.Parallel()
+
+		tg := Tag{
+			Bytes: []byte("<tagname />"),
+		}
+		rq.Equal("", tg.Name)
+
+		err := tg.SetName()
+		rq.NoError(err)
+		rq.Equal("tagname", tg.Name)
+	})
+
+	t.Run("with attribute", func(t *testing.T) {
+		t.Parallel()
+
+		tg := Tag{
+			Bytes: []byte("<tagname attr='value'>"),
+		}
+		rq.Equal("", tg.Name)
+
+		err := tg.SetName()
+		rq.NoError(err)
+		rq.Equal("tagname", tg.Name)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		tg := Tag{
+			Bytes: []byte("tagname attr='value'>"),
+		}
+		rq.Equal("", tg.Name)
+
+		err := tg.SetName()
+		rq.Error(err)
+	})
+}
+
+func TestTagSetNameAndAttributes(t *testing.T) {
+	t.Parallel()
+	rq := require.New(t)
+
+	t.Run("ok", func(t *testing.T) {
+		t.Parallel()
+
+		tg := Tag{
+			Bytes: []byte("<tagname attr='value'>"),
+		}
+		rq.Equal("", tg.Name)
+		rq.Len(tg.Attributes, 0)
+
+		err := tg.SetNameAndAttributes()
+		rq.NoError(err)
+		rq.Equal("tagname", tg.Name)
+		rq.Len(tg.Attributes, 1)
+		v, ok := tg.Attributes["attr"]
+		rq.True(ok)
+		rq.Equal("value", v)
+	})
+
+	t.Run("ok: several attributes", func(t *testing.T) {
+		t.Parallel()
+
+		tg := Tag{
+			Bytes: []byte(`<tagname attr="value" data="datavalue" number="42">`),
+		}
+		rq.Equal("", tg.Name)
+		rq.Len(tg.Attributes, 0)
+
+		err := tg.SetNameAndAttributes()
+		rq.NoError(err)
+		rq.Equal("tagname", tg.Name)
+		rq.Len(tg.Attributes, 3)
+		v, ok := tg.Attributes["attr"]
+		rq.True(ok)
+		rq.Equal("value", v)
+		d, ok := tg.Attributes["data"]
+		rq.True(ok)
+		rq.Equal("datavalue", d)
+		n, ok := tg.Attributes["number"]
+		rq.True(ok)
+		rq.Equal("42", n)
+		rq.Equal("datavalue", d)
+		f, ok := tg.Attributes["notfound"]
+		rq.False(ok)
+		rq.Equal("", f)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		tg := Tag{
+			Bytes: []byte("tagname attr='value'>"),
+		}
+		rq.Equal("", tg.Name)
+
+		err := tg.SetNameAndAttributes()
+		rq.Error(err)
+	})
+
+	t.Run("close tag", func(t *testing.T) {
+		t.Parallel()
+
+		tg := Tag{
+			Bytes: []byte("</tagname>"),
+		}
+		rq.Equal("", tg.Name)
+
+		err := tg.SetNameAndAttributes()
+		rq.NoError(err)
+		rq.Equal("tagname", tg.Name)
+		rq.Len(tg.Attributes, 0)
+	})
+}

--- a/internal/domain/tag_test.go
+++ b/internal/domain/tag_test.go
@@ -1,0 +1,60 @@
+package domain
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateTag(t *testing.T) {
+	t.Parallel()
+	rq := require.New(t)
+
+	t.Run("too short", func(t *testing.T) {
+		t.Parallel()
+
+		tg := Tag{
+			Bytes: []byte("<b"),
+		}
+
+		err := tg.Validate()
+		rq.Error(err)
+		rq.True(errors.Is(err, ErrTagShort))
+	})
+
+	t.Run("invalid start", func(t *testing.T) {
+		t.Parallel()
+
+		tg := Tag{
+			Bytes: []byte("tagName attr='value'>"),
+		}
+
+		err := tg.Validate()
+		rq.Error(err)
+		rq.True(errors.Is(err, ErrTagInvalidStart))
+	})
+
+	t.Run("invalid end", func(t *testing.T) {
+		t.Parallel()
+
+		tg := Tag{
+			Bytes: []byte("<tagName attr='value'"),
+		}
+
+		err := tg.Validate()
+		rq.Error(err)
+		rq.True(errors.Is(err, ErrTagInvalidEnd))
+	})
+
+	t.Run("invalid end", func(t *testing.T) {
+		t.Parallel()
+
+		tg := Tag{
+			Bytes: []byte("<tagName attr='value'>"),
+		}
+
+		err := tg.Validate()
+		rq.NoError(err)
+	})
+}

--- a/internal/processors/attributes/attributes.go
+++ b/internal/processors/attributes/attributes.go
@@ -16,9 +16,10 @@ import (
 type (
 	// Processor is an attrubute processor. Keeps needed attributes to process data and handle attribute data.
 	Processor struct {
-		targetAttributesList []string
-		path                 []domain.Step
+		queryPath            []domain.Step
+		currentPath          []string
 		attribute            string
+		targetAttributesList []string
 	}
 )
 
@@ -32,7 +33,7 @@ func NewProcessor(path []domain.Step, attribute string) (*Processor, error) {
 	}
 
 	return &Processor{
-		path:      path,
+		queryPath: path,
 		attribute: attribute,
 	}, nil
 }
@@ -67,4 +68,6 @@ func (p *Processor) printAttrubutes() {
 	}
 }
 
-func (p *Processor) process(chunk []byte) {}
+func (p *Processor) process(chunk []byte) {
+
+}

--- a/internal/processors/attributes/attributes.go
+++ b/internal/processors/attributes/attributes.go
@@ -17,7 +17,6 @@ type (
 	// Processor is an attrubute processor. Keeps needed attributes to process data and handle attribute data.
 	Processor struct {
 		queryPath            []domain.Step
-		currentPath          []string
 		attribute            string
 		targetAttributesList []string
 	}
@@ -69,5 +68,4 @@ func (p *Processor) printAttrubutes() {
 }
 
 func (p *Processor) process(chunk []byte) {
-
 }


### PR DESCRIPTION
This is the alternative way to process tags.
Move logic to `domain` package and make universal logic for all type of processes. 